### PR TITLE
[PS-22912] fix crash from upgrading to react native 61.5

### DIFF
--- a/android/src/main/java/com/bolan9999/SpringScrollView.java
+++ b/android/src/main/java/com/bolan9999/SpringScrollView.java
@@ -471,7 +471,7 @@ public class SpringScrollView extends ReactViewGroup implements View.OnTouchList
         WritableMap contentOffsetMap = Arguments.createMap();
         contentOffsetMap.putDouble("x", PixelUtil.toDIPFromPixel(contentOffset.x));
         contentOffsetMap.putDouble("y", PixelUtil.toDIPFromPixel(contentOffset.y));
-        event.putMap("contentOffset", contentOffsetMap);
+        event.putMap("contentOffset", (ReadableMap)contentOffsetMap);
         event.putString("refreshStatus", refreshStatus);
         event.putString("loadingStatus", loadingStatus);
         sendOnScrollEvent(event);


### PR DESCRIPTION
React Native 61+ changed the type in putMap to accept a ReadableMap instead of a WritableMap. Casting the argument to WritableMap to fix the crash.

![android-trophy-crash](https://user-images.githubusercontent.com/22797037/85045169-77db3000-b143-11ea-9d39-034cd7ddd138.gif)
